### PR TITLE
Fix linker command line argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. The format 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix linker command line argument order in Makefile
 
 ## [0.2.0] - 2019-09-08
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # This file is part of aircontrol.
 # 
-# Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+# Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
 # 
 # aircontrol is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ DEPS:=$(OBJ:.o=.d)
 
 $(BIN_DIR)/$(APP): pre-build scripts/version.sh $(OBJ)
 	@mkdir -p $(BIN_DIR)
-	$(CC) $(LDFLAGS) $(OBJ) -o $@
+	$(CC) -o $@ $(OBJ) $(LDFLAGS)
 
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
 	@mkdir -p $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ If you are controlling other devices with aircontrol please let me know.
 aircontrol needs to be compiled on a Raspberry Pi (or on a host with a compatible cross tool chain).
 The following libraries are needed:
 
-* **WiringPi**, see <http://wiringpi.com/download-and-install/>
-* **libconfig++**, as root install with: `apt-get install libconfig++-dev`
+* **[WiringPi](http://wiringpi.com)**, as root install with: `apt-get install wiringpi`
+* **[libconfig++](https://www.hyperrealm.com/oss_libconfig.shtml)**, as root install with: `apt-get install libconfig++9v5 libconfig++-dev`
 
 Perform the following steps to compile and install aircontrol:
 

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/InstanceLock.h
+++ b/include/InstanceLock.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/Replay.h
+++ b/include/Replay.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/ReplayParameters.h
+++ b/include/ReplayParameters.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/Scan.h
+++ b/include/Scan.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/ScanParameters.h
+++ b/include/ScanParameters.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/Target.h
+++ b/include/Target.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/TargetParameters.h
+++ b/include/TargetParameters.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/Task.h
+++ b/include/Task.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/include/Types.h
+++ b/include/Types.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/Configuration.cpp
+++ b/source/Configuration.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/InstanceLock.cpp
+++ b/source/InstanceLock.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/Replay.cpp
+++ b/source/Replay.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/ReplayParameters.cpp
+++ b/source/ReplayParameters.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/Scan.cpp
+++ b/source/Scan.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/ScanParameters.cpp
+++ b/source/ScanParameters.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/Target.cpp
+++ b/source/Target.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/TargetParameters.cpp
+++ b/source/TargetParameters.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/Task.cpp
+++ b/source/Task.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/source/aircontrol.cpp
+++ b/source/aircontrol.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of aircontrol.
  *
- * Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>
+ * Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>
  *
  * aircontrol is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@ static void printUsage(void) {
         << "  -s <ms>\tAir scan for given period" << std::endl
         << "  -t <target>\tExecute target configuration" << std::endl
         << std::endl
-        << "Copyright (C) 2014-2019 Ralf Dauberschmidt <ralf@dauberschmidt.de>"
+        << "Copyright (C) 2014-2022 Ralf Dauberschmidt <ralf@dauberschmidt.de>"
         << std::endl << std::endl;
 }
 


### PR DESCRIPTION
GCC 10 (on Raspbian Bullseye) does not accept the previous linker argument order, which GCC 8 (on Raspbian Buster) did.